### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://devopsokn.visualstudio.com/85db4e96-6f1b-4ea7-b9ff-c64cf22e862f/befe8b88-77fe-4695-a5ce-95ec38d6f459/_apis/work/boardbadge/dc045cde-a020-456d-91a9-2c137bd0d823)](https://devopsokn.visualstudio.com/85db4e96-6f1b-4ea7-b9ff-c64cf22e862f/_boards/board/t/befe8b88-77fe-4695-a5ce-95ec38d6f459/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#78](https://devopsokn.visualstudio.com/85db4e96-6f1b-4ea7-b9ff-c64cf22e862f/_workitems/edit/78). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.